### PR TITLE
A quick implementation of doubleclickrowindex() for treetables

### DIFF
--- a/ldtpd/table.py
+++ b/ldtpd/table.py
@@ -964,7 +964,7 @@ class Table(Utils):
         @return: row index matching the text on success.
         @rtype: integer
         """
-	obj = self._get_object(window_name, object_name)
+        obj = self._get_object(window_name, object_name)
 
         try:
             tablei = obj.queryTable()


### PR DESCRIPTION
This is useful to me for doubleclicking a row in a treetable which has the same text as another earlier in the tree.
