### PR TITLE
Add QT_LINUX_ACCESSIBILITY_ALWAYS_ON environment variable.

### DIFF
--- a/doc/ldtp-doc.doxygen
+++ b/doc/ldtp-doc.doxygen
@@ -5866,7 +5866,7 @@
  * launchapp('\<application binary name\>'[, argument] [,delay = 5][,
  * env = 1])
  *
- * second and third arguments are optional. environment default argument is 1. So the GTK_MODULES and GNOME_ACCESSIBILITY will be set and added to the enivronment variable.
+ * second and third arguments are optional. environment default argument is 1. So the GTK_MODULES, GNOME_ACCESSIBILITY and QT_LINUX_ACCESSIBILITY_ALWAYS_ON will be set and added to the enivronment variable.
  *
  * Delay is wait time(in seconds) after launching the application
  *

--- a/ldtpd/core.py
+++ b/ldtpd/core.py
@@ -265,6 +265,7 @@ class Ldtpd(Utils, ComboBox, Table, Menu, PageTabList,
         if env:
             os.environ['GTK_MODULES']='gail:atk-bridge'
             os.environ['GNOME_ACCESSIBILITY']='1'
+            os.environ['QT_LINUX_ACCESSIBILITY_ALWAYS_ON']='1'
         if lang:
             os.environ['LANG']=lang
         try:


### PR DESCRIPTION
Unfortunately tools like qmlscene and others don't register the at-spi bridge if the gnome screen reader is not turned on permanently. With this patch we can force qt applications to register independently of the system wide setting. 

See:  https://bugreports.qt.io/browse/QTBUG-49680