### PR TITLE
Improved CobraWinLDTP/ldtp/log.py for better debug log output on console

### DIFF
--- a/ldtp/log.py
+++ b/ldtp/log.py
@@ -3,15 +3,15 @@ LDTP v2 client init file
 
 @author: Eitan Isaacson <eitan@ascender.com>
 @author: Nagappan Alagappan <nagappan@gmail.com>
-@copyright: Copyright (c) 2009 Eitan Isaacson
 @copyright: Copyright (c) 2009-13 Nagappan Alagappan
+@copyright: Copyright (c) 2009 Eitan Isaacson
 @license: LGPL
 
 http://ldtp.freedesktop.org
 
 This file may be distributed and/or modified under the terms of the GNU Lesser General
 Public License version 2 as published by the Free Software Foundation. This file
-is distributed without any warranty; without even the implied warranty of 
+is distributed without any warranty; without even the implied warranty of
 merchantability or fitness for a particular purpose.
 
 See 'COPYING' in the source distribution for more information.
@@ -25,6 +25,12 @@ import logging
 AREA = 'ldtp.client'
 ENV_LOG_LEVEL = 'LDTP_LOG_LEVEL'
 ENV_LOG_OUT = 'LDTP_LOG_OUT'
+ENV_LOG_STYLE = 'LDTP_LOG_STYLE'
+
+
+class noParsingFilter(logging.Filter):
+    def filter(self, record):
+        return record.getMessage().rfind('getlastlog()')
 
 log_level = getattr(logging, env.get(ENV_LOG_LEVEL, 'NOTSET'), logging.NOTSET)
 
@@ -32,13 +38,19 @@ logger = logging.getLogger(AREA)
 
 if ENV_LOG_OUT not in env:
     handler = logging.StreamHandler()
-    handler.setFormatter(
-        logging.Formatter('%(name)-11s %(levelname)-8s %(message)s'))
+    if ENV_LOG_STYLE in env and env[ENV_LOG_STYLE].lower() == 'short':
+        handler.setFormatter(
+            logging.Formatter('%(name)-11s %(levelname)-8s %(message)s'))
+    else:
+        handler.setFormatter(
+            logging.Formatter('%(asctime)s %(levelname)-8s %(message)s'))
 else:
     handler = logging.FileHandler(env[ENV_LOG_OUT])
     handler.setFormatter(
         logging.Formatter('%(asctime)s %(levelname)-8s %(message)s'))
 
 logger.addHandler(handler)
+
+logger.addFilter(noParsingFilter())
 
 logger.setLevel(log_level)


### PR DESCRIPTION
Now `getlastlog()` does not appear in debug log. And by default, every debug log entry on the console has a time stamp. The user could choose to use the old style console debug log by setting environmental variable `LDTP_LOG_STYLE=short`.