### PR TITLE
added 'terminal' into obj_types in gettextvalue method

### DIFF
--- a/ldtpd/text.py
+++ b/ldtpd/text.py
@@ -163,7 +163,8 @@ class Text(Utils):
         """
         obj=self._get_object(window_name, object_name,
                              obj_type=['combo_box', 'text', 'entry', 'label',
-                                       'paragraph', 'password_text', 'editbar'])
+                                       'paragraph', 'password_text', 'editbar',
+                                       'terminal'])
         if obj.getRole() == pyatspi.ROLE_COMBO_BOX:
             child_obj=self._get_combo_child_object_type(obj)
             if child_obj.getRole() == pyatspi.ROLE_LIST:


### PR DESCRIPTION
Application gnome-terminal contains of text frame with class='terminal'. This frame is a visual window with a text that was written in terminal.

I was not able to get text from a terminal. This is due to a obj_type filter inside gettextvalue.
This filter does not accept obj_type 'terminal'.

I have added this type into gettextvalue method.
