### PR TITLE
added an argument to the method 'main'

### DIFF
--- a/ldtpd/__init__.py
+++ b/ldtpd/__init__.py
@@ -36,7 +36,7 @@ class SignalParent:
 
 
 from xmlrpc_daemon import XMLRPCLdtpd
-def main(port=4118, parentpid=None, XMLRPCLdtpdFactory = lambda: XMLRPCLdtpd()):
+def main(port=4118, parentpid=None, XMLRPCLdtpdFactory=lambda: XMLRPCLdtpd()):
     import os
     os.environ['NO_GAIL'] = '1'
     os.environ['NO_AT_BRIDGE'] = '1'

--- a/ldtpd/__init__.py
+++ b/ldtpd/__init__.py
@@ -34,7 +34,9 @@ class SignalParent:
 
         os.kill(int(self.parentpid), signal.SIGUSR1)
 
-def main(port=4118, parentpid=None):
+
+from xmlrpc_daemon import XMLRPCLdtpd
+def main(port=4118, parentpid=None, XMLRPCLdtpdFactory = lambda: XMLRPCLdtpd()):
     import os
     os.environ['NO_GAIL'] = '1'
     os.environ['NO_AT_BRIDGE'] = '1'
@@ -61,7 +63,6 @@ def main(port=4118, parentpid=None):
             pass
     from twisted.internet import reactor
     from twisted.web import server, xmlrpc
-    from xmlrpc_daemon import XMLRPCLdtpd
     import twisted.internet
     import socket
     import pyatspi
@@ -72,7 +73,7 @@ def main(port=4118, parentpid=None):
 
     try:
         pyatspi.setCacheLevel(pyatspi.CACHE_PROPERTIES)
-        r = XMLRPCLdtpd()
+        r = XMLRPCLdtpdFactory()
         xmlrpc.addIntrospection(r)
         if parentpid:
             reactor.callWhenRunning(SignalParent(parentpid).send_later)


### PR DESCRIPTION
Hello, purpose of this change is to have an easy way to extend a list of xmlrpc methods offered by ldtpd.

I have tested this simple example:

``` python
#!/usr/bin/python
import ldtpd
from ldtpd.xmlrpc_daemon import XMLRPCLdtpd
from dogtail import tree

class RHSM_LDTPD(XMLRPCLdtpd):
    def xmlrpc_do_action_named(self, path, action):
        """
        This method performs an action on some element.
        The element is located by dogtail in the application 'subscription-manager-gui'.

        @param  path:  a coordinates of the table with the requested 'table cell header'.
                       The format of a path: [{'name': 'some name', roleName = 'some role'}, {}]
                       The format conforms to a dogtail format.
                       This method uses dogtail to perform an action.
        @param action: The name of an action that will be used.
        @return boolean: True - the action was succeeded.
                          False - some error occured.
        """
        submangui = next(iter([app for app in tree.root.applications()
                               if 'subscription-manager-gui' == app.name and app.children]), None)
        if not submangui:
            return False

        def getChild(acc, path):
            return acc.child(**path)

        child = reduce(getChild,path,submangui)
        result = child.doActionNamed(action)
        return result

if __name__ == '__main__':
    ldtpd.main(XMLRPCLdtpdFactory = lambda: RHSM_LDTPD())
```

This works.