### PR TITLE
exception just in case that cell.name is None

### DIFF
--- a/ldtpd/table.py
+++ b/ldtpd/table.py
@@ -495,7 +495,7 @@ class Table(Utils):
         else:
             name = cell.name
             self._grab_focus(cell)
-        if not name:
+        if name is None:
             raise LdtpServerException('Unable to get row text')
         return name
 


### PR DESCRIPTION
Hello Nagappan,
I have a problem to read empty string from an empty column cell.

![after-first-click](https://cloud.githubusercontent.com/assets/2276410/19526318/54ae6cb6-9624-11e6-9922-9ff60edff1df.jpg)

It is 'Start Date' column in the attached image.
LDTP raises exception 'Unable to get row text'.
I dig into the code and code.name=="" - ie. empty string.
It would help me that ldtp gives empty string in such case instead of raising an exeption.

I have tested this a solution like this:

```python
if code.name is None:
   raise Exception....
```

I do not know a strategy of raising exceptions. So I hope this solution does not break this strategy.

Have a good day,
Jan Stavel