### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty # Qt5, from https://gist.github.com/jreese/6207161#gistcomment-1462109
 
 install:
   # LDTP

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: required
+
+install:
+  # LDTP
+  - sudo apt-get install python-twisted-web
+  - sudo apt-get install python-wnck
+  - sudo apt-get install python-gnome
+  # Documentation
+  #- sudo apt-get install rst2pdf
+
+script:
+  # Build LDTP
+  - python setup.py build
+  - sudo python setup.py install
+  # Build documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ script:
   - python setup.py build
   - sudo python setup.py install
   # Build documentation
+  # Build and run examples

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   # LDTP
   - sudo apt-get install python-twisted-web
   - sudo apt-get install python-wnck
-  - sudo apt-get install python-gnome
+  #- sudo apt-get install python-gnome
   # Documentation
   #- sudo apt-get install rst2pdf
 

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 LDTP
 ====
 
-.. image:: https://travis-ci.org/richelbilderbeek/ldtp2.svg?branch=master
-    :target: https://travis-ci.org/richelbilderbeek/ldtp2
+.. image:: https://travis-ci.org/ldtp/ldtp2.svg?branch=master
+    :target: https://travis-ci.org/ldtp/ldtp2
 
 `LDTP <http://ldtp.freedesktop.org>`_ is the best cross platform GUI testing
 tool out there. Why? Because it works on Linux, Windows, OS X, Solaris,

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,9 @@
 LDTP
 ====
 
+.. image:: https://travis-ci.org/richelbilderbeek/ldtp2.svg?branch=master
+    :target: https://travis-ci.org/richelbilderbeek/ldtp2
+
 `LDTP <http://ldtp.freedesktop.org>`_ is the best cross platform GUI testing
 tool out there. Why? Because it works on Linux, Windows, OS X, Solaris,
 FreeBSD, NetBSD, and Palm Source. Your feedback is much appreciated, please


### PR DESCRIPTION
As discussed at #33 . It adds a Travis configuration file and displays a Travis build badge on the readme. Testing is limited: it only checks if installation works. Additional tests can be added rather easily.

Do not forget to activate a Travis CI account at www.travis-ci.org

Thanks for helping FLOSS to be great!



