### PR TITLE
Get desktop screen resolution using gtk/Gdk, rather than pyatspi getExtents

### DIFF
--- a/ldtpd/mouse.py
+++ b/ldtpd/mouse.py
@@ -152,11 +152,11 @@ class Mouse(Utils):
         @return: 1 if simulation was successful, 0 if not.
         @rtype: integer
         """
-        size = self._get_size(self._desktop)
-        if (source_x < size.x or source_y < size.y or \
-                dest_x > size.width or dest_y > size.height) or \
-                (source_x > size.width or source_y > size.height or \
-                     dest_x < size.x or dest_y < size.y):
+        size = self._get_geometry()
+        if (source_x < size[0] or source_y < size[1] or \
+                dest_x > size[2] or dest_y > size[3]) or \
+                (source_x > size[2] or source_y > size[3] or \
+                     dest_x < size[0] or dest_y < size[1]):
             return 0
 
         x_flag = False # Iterated x ?

--- a/ldtpd/utils.py
+++ b/ldtpd/utils.py
@@ -29,6 +29,14 @@ import pyatspi
 import threading
 import traceback
 import logging.handlers
+try:
+  # If we have gtk3+ gobject introspection, use that
+  from gi.repository import Gdk
+  gtk3 = True
+except:
+  # No gobject introspection, use gtk2
+  import gtk
+  gtk3 = False
 from re import match as re_match
 from constants import abbreviated_roles
 from fnmatch import translate as glob_trans
@@ -205,6 +213,10 @@ class Utils:
                     self.cached_apps.append([app, True])
         if self._ldtp_debug:
             _custom_logger.setLevel(logging.DEBUG)
+        if gtk3:
+            self._root_window = Gdk.get_default_root_window()
+        else:
+            self._root_window = gtk.gdk.get_default_root_window()
 
     def _get_all_state_names(self):
         """
@@ -369,6 +381,15 @@ class Utils:
                 # In at-spi2 gi._glib.GError exception is thrown
                 # If the window doesn't exist, remove from the cached list
                 self.cached_apps.remove(app)
+
+    def _get_geometry(self):
+        """
+        Get the geometry of the default root window.
+        @return: Coordinates of every corner of the default root window.
+        @rtype: tuple
+        """
+        geometry = self._root_window.get_geometry()
+        return geometry
 
     def _ldtpize_accessible(self, acc):
         """


### PR DESCRIPTION
_get_size always returns 1024 x 768 regardless of the resolution of the desktop. This was tested on a desktop with a resolution of 1920 x 1080. This constrained simulatemousemove to a smaller area of the screen. I replaced the method of getting the screen size to gtk/Gdk's get_geometry() function on the get_default_root_window() object.