### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ See 'COPYING' in the source distribution for more information.
 Headers in this file shall remain intact.
 """
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name="ldtp",
       version="3.5.0",
@@ -29,6 +29,7 @@ setup(name="ldtp",
       maintainer_email="nagappan@gmail.com",
       url="http://ldtp.freesktop.org",
       license="GNU Lesser General Public License (LGPL)",
+      install_requires=["twisted"],
       packages=["ldtp", "ldtpd", "ooldtp", "ldtputils"],
       long_description="Linux Desktop Testing Project is aimed at producing " \
           "high quality cross platform GUI test automation framework and cutting-edge tools that " \


### PR DESCRIPTION
Move to setuptools and add twisted to install_required

This makes it easier (though not quite straightforward) to use in a virtualenv with vext, since only pyatspi and gi.repository are needed from the system python.